### PR TITLE
Deprecations to create in 2.6.0

### DIFF
--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -62,8 +62,8 @@ class EventManager implements EventManagerInterface
     /**
      * Set the event class to utilize
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  string $class
      * @return EventManager
@@ -77,8 +77,8 @@ class EventManager implements EventManagerInterface
     /**
      * Set shared event manager
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param SharedEventManagerInterface $sharedEventManager
      * @return EventManager
@@ -93,8 +93,8 @@ class EventManager implements EventManagerInterface
     /**
      * Remove any shared event manager currently attached
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @return void
      */
@@ -221,12 +221,14 @@ class EventManager implements EventManagerInterface
      * Triggers listeners until the provided callback evaluates the return
      * value of one as true, or until all listeners have been executed.
      *
+     * @deprecated The signature of this method will change in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/changed.md}
+     *     for details.
      * @param  string|EventInterface $event
      * @param  string|object $target Object calling emit, or symbol describing target (such as static method name)
      * @param  array|ArrayAccess $argv Array of arguments; typically, should be associative
      * @param  callable $callback
      * @return ResponseCollection
-     * @deprecated Please use trigger()
      * @throws Exception\InvalidCallbackException if invalid callable provided
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null)
@@ -325,8 +327,8 @@ class EventManager implements EventManagerInterface
      * one or more times, typically to attach to multiple events using local
      * methods.
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @param  int $priority If provided, a suggested priority for the aggregate to use
@@ -378,8 +380,8 @@ class EventManager implements EventManagerInterface
      * Listener aggregates accept an EventManagerInterface instance, and call detach()
      * of all previously attached listeners.
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @return mixed return value of {@link ListenerAggregateInterface::detach()}
@@ -392,8 +394,8 @@ class EventManager implements EventManagerInterface
     /**
      * Retrieve all registered events
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @return array
      */
@@ -405,8 +407,8 @@ class EventManager implements EventManagerInterface
     /**
      * Retrieve all listeners for a given event
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  string $event
      * @return PriorityQueue

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -62,6 +62,9 @@ class EventManager implements EventManagerInterface
     /**
      * Set the event class to utilize
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  string $class
      * @return EventManager
      */
@@ -74,6 +77,9 @@ class EventManager implements EventManagerInterface
     /**
      * Set shared event manager
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param SharedEventManagerInterface $sharedEventManager
      * @return EventManager
      */
@@ -87,6 +93,9 @@ class EventManager implements EventManagerInterface
     /**
      * Remove any shared event manager currently attached
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @return void
      */
     public function unsetSharedManager()
@@ -230,6 +239,29 @@ class EventManager implements EventManagerInterface
     }
 
     /**
+     * Trigger an event instance.
+     *
+     * @param EventInterface $event
+     * @return ResponseCollection
+     */
+    public function triggerEvent(EventInterface $event)
+    {
+        return $this->triggerListeners($event->getName(), $event);
+    }
+
+    /**
+     * Trigger an event instance, short-circuiting if a listener response evaluates true via the callback.
+     *
+     * @param callable $callback
+     * @param EventInterface $event
+     * @return ResponseCollection
+     */
+    public function triggerEventUntil(callable $callback, EventInterface $event)
+    {
+        return $this->triggerListeners($event->getName(), $event, $callback);
+    }
+
+    /**
      * Attach a listener to an event
      *
      * The first argument is the event, and the next argument describes a
@@ -293,6 +325,9 @@ class EventManager implements EventManagerInterface
      * one or more times, typically to attach to multiple events using local
      * methods.
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @param  int $priority If provided, a suggested priority for the aggregate to use
      * @return mixed return value of {@link ListenerAggregateInterface::attach()}
@@ -343,6 +378,9 @@ class EventManager implements EventManagerInterface
      * Listener aggregates accept an EventManagerInterface instance, and call detach()
      * of all previously attached listeners.
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @return mixed return value of {@link ListenerAggregateInterface::detach()}
      */
@@ -354,6 +392,9 @@ class EventManager implements EventManagerInterface
     /**
      * Retrieve all registered events
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @return array
      */
     public function getEvents()
@@ -364,6 +405,9 @@ class EventManager implements EventManagerInterface
     /**
      * Retrieve all listeners for a given event
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  string $event
      * @return PriorityQueue
      */

--- a/src/EventManagerInterface.php
+++ b/src/EventManagerInterface.php
@@ -44,12 +44,14 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
      * - Passing event name, target, Event object, and callback
      * - Passing event name, target, array|ArrayAccess of arguments, and callback
      *
+     * @deprecated The signature of this method will change in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/changed.md}
+     *     for details.
      * @param  string|EventInterface $event
      * @param  object|string $target
      * @param  array|object $argv
      * @param  callable $callback
      * @return ResponseCollection
-     * @deprecated Please use trigger()
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null);
 
@@ -74,8 +76,8 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Get a list of events for which this collection has listeners
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @return array
      */
@@ -84,8 +86,8 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Retrieve a list of listeners registered to a given event
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  string $event
      * @return array|object
@@ -103,8 +105,8 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Set the event class to utilize
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  string $class
      * @return EventManagerInterface
@@ -137,8 +139,8 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Attach a listener aggregate
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @param  int $priority If provided, a suggested priority for the aggregate to use
@@ -149,8 +151,8 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Detach a listener aggregate
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @return mixed return value of {@link ListenerAggregateInterface::detach()}

--- a/src/EventManagerInterface.php
+++ b/src/EventManagerInterface.php
@@ -74,6 +74,9 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Get a list of events for which this collection has listeners
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @return array
      */
     public function getEvents();
@@ -81,6 +84,9 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Retrieve a list of listeners registered to a given event
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  string $event
      * @return array|object
      */
@@ -97,6 +103,9 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Set the event class to utilize
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  string $class
      * @return EventManagerInterface
      */
@@ -128,6 +137,9 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Attach a listener aggregate
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @param  int $priority If provided, a suggested priority for the aggregate to use
      * @return mixed return value of {@link ListenerAggregateInterface::attach()}
@@ -137,6 +149,9 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
     /**
      * Detach a listener aggregate
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  ListenerAggregateInterface $aggregate
      * @return mixed return value of {@link ListenerAggregateInterface::detach()}
      */

--- a/src/GlobalEventManager.php
+++ b/src/GlobalEventManager.php
@@ -18,8 +18,8 @@ use Zend\Stdlib\PriorityQueue;
  * Use the EventManager when you want to create a per-instance notification
  * system for your objects.
  *
- * @deprecated This class is deprecated with 2.6.0, and will be removed in
- *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ * @deprecated This class is deprecated with 2.6.0, and will be removed in 3.0.0.
+ *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
  *     for details.
  */
 class GlobalEventManager

--- a/src/GlobalEventManager.php
+++ b/src/GlobalEventManager.php
@@ -17,6 +17,10 @@ use Zend\Stdlib\PriorityQueue;
  *
  * Use the EventManager when you want to create a per-instance notification
  * system for your objects.
+ *
+ * @deprecated This class is deprecated with 2.6.0, and will be removed in
+ *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ *     for details.
  */
 class GlobalEventManager
 {

--- a/src/SharedEventAggregateAwareInterface.php
+++ b/src/SharedEventAggregateAwareInterface.php
@@ -11,6 +11,10 @@ namespace Zend\EventManager;
 
 /**
  * Interface for allowing attachment of shared aggregate listeners.
+ *
+ * @deprecated This interface is deprecated with 2.6.0, and will be removed in
+ *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ *     for details.
  */
 interface SharedEventAggregateAwareInterface
 {

--- a/src/SharedEventAggregateAwareInterface.php
+++ b/src/SharedEventAggregateAwareInterface.php
@@ -12,8 +12,8 @@ namespace Zend\EventManager;
 /**
  * Interface for allowing attachment of shared aggregate listeners.
  *
- * @deprecated This interface is deprecated with 2.6.0, and will be removed in
- *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ * @deprecated This interface is deprecated with 2.6.0, and will be removed in 3.0.0.
+ *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
  *     for details.
  */
 interface SharedEventAggregateAwareInterface

--- a/src/SharedEventManager.php
+++ b/src/SharedEventManager.php
@@ -123,8 +123,8 @@ class SharedEventManager implements
     /**
      * Retrieve all registered events for a given resource
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  string|int $id
      * @return array

--- a/src/SharedEventManager.php
+++ b/src/SharedEventManager.php
@@ -123,6 +123,9 @@ class SharedEventManager implements
     /**
      * Retrieve all registered events for a given resource
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  string|int $id
      * @return array
      */

--- a/src/SharedEventManagerAwareInterface.php
+++ b/src/SharedEventManagerAwareInterface.php
@@ -12,8 +12,8 @@ namespace Zend\EventManager;
 /**
  * Interface to automate setter injection for a SharedEventManagerInterface instance
  *
- * @deprecated This interface is deprecated with 2.6.0, and will be removed in
- *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ * @deprecated This interface is deprecated with 2.6.0, and will be removed in 3.0.0.
+ *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
  *     for details.
  */
 interface SharedEventManagerAwareInterface extends SharedEventsCapableInterface

--- a/src/SharedEventManagerAwareInterface.php
+++ b/src/SharedEventManagerAwareInterface.php
@@ -11,8 +11,12 @@ namespace Zend\EventManager;
 
 /**
  * Interface to automate setter injection for a SharedEventManagerInterface instance
+ *
+ * @deprecated This interface is deprecated with 2.6.0, and will be removed in
+ *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ *     for details.
  */
-interface SharedEventManagerAwareInterface
+interface SharedEventManagerAwareInterface extends SharedEventsCapableInterface
 {
     /**
      * Inject a SharedEventManager instance
@@ -21,13 +25,6 @@ interface SharedEventManagerAwareInterface
      * @return SharedEventManagerAwareInterface
      */
     public function setSharedManager(SharedEventManagerInterface $sharedEventManager);
-
-    /**
-     * Get shared collections container
-     *
-     * @return SharedEventManagerInterface
-     */
-    public function getSharedManager();
 
     /**
      * Remove any shared collections

--- a/src/SharedEventManagerInterface.php
+++ b/src/SharedEventManagerInterface.php
@@ -49,8 +49,8 @@ interface SharedEventManagerInterface
     /**
      * Retrieve all registered events for a given resource
      *
-     * @deprecated This method is deprecated with 2.6.0, and will be removed in
-     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in 3.0.0.
+     *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
      *     for details.
      * @param  string|int $id
      * @return array

--- a/src/SharedEventManagerInterface.php
+++ b/src/SharedEventManagerInterface.php
@@ -49,6 +49,9 @@ interface SharedEventManagerInterface
     /**
      * Retrieve all registered events for a given resource
      *
+     * @deprecated This method is deprecated with 2.6.0, and will be removed in
+     *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+     *     for details.
      * @param  string|int $id
      * @return array
      */

--- a/src/SharedEventsCapableInterface.php
+++ b/src/SharedEventsCapableInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-eventmanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-eventmanager/blob/master/LICENSE.md
+ */
+
+namespace Zend\EventManager;
+
+/**
+ * Interface indicating that an object composes or can compose a
+ * SharedEventManagerInterface instance.
+ */
+interface SharedEventsCapableInterface
+{
+    /**
+     * Retrieve the shared event manager, if composed.
+     *
+     * @return null|SharedEventManagerInterface
+     */
+    public function getSharedManager();
+}

--- a/src/SharedListenerAggregateInterface.php
+++ b/src/SharedListenerAggregateInterface.php
@@ -17,8 +17,8 @@ namespace Zend\EventManager;
  * then be called with the current SharedEventManager instance, allowing the class to
  * wire up one or more listeners.
  *
- * @deprecated This interface is deprecated with 2.6.0, and will be removed in
- *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ * @deprecated This interface is deprecated with 2.6.0, and will be removed in 3.0.0.
+ *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
  *     for details.
  */
 interface SharedListenerAggregateInterface

--- a/src/SharedListenerAggregateInterface.php
+++ b/src/SharedListenerAggregateInterface.php
@@ -16,6 +16,10 @@ namespace Zend\EventManager;
  * with a SharedEventManager, without an event name. The {@link attach()} method will
  * then be called with the current SharedEventManager instance, allowing the class to
  * wire up one or more listeners.
+ *
+ * @deprecated This interface is deprecated with 2.6.0, and will be removed in
+ *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ *     for details.
  */
 interface SharedListenerAggregateInterface
 {

--- a/src/StaticEventManager.php
+++ b/src/StaticEventManager.php
@@ -11,6 +11,10 @@ namespace Zend\EventManager;
 
 /**
  * Static version of EventManager
+ *
+ * @deprecated This class is deprecated with 2.6.0, and will be removed in
+ *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ *     for details.
  */
 class StaticEventManager extends SharedEventManager
 {

--- a/src/StaticEventManager.php
+++ b/src/StaticEventManager.php
@@ -12,8 +12,8 @@ namespace Zend\EventManager;
 /**
  * Static version of EventManager
  *
- * @deprecated This class is deprecated with 2.6.0, and will be removed in
- *     3.0.0. See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
+ * @deprecated This class is deprecated with 2.6.0, and will be removed in 3.0.0.
+ *     See {@link https://github.com/zendframework/zend-eventmanager/blob/develop/doc/book/migration/removed.md}
  *     for details.
  */
 class StaticEventManager extends SharedEventManager

--- a/test/EventManagerTest.php
+++ b/test/EventManagerTest.php
@@ -201,10 +201,13 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testTriggerUntilShouldMarkResponseCollectionStoppedWhenConditionMet()
     {
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function () { return 'bogus'; }, 4);
         $this->events->attach('foo.bar', function () { return 'nada'; }, 3);
         $this->events->attach('foo.bar', function () { return 'found'; }, 2);
         $this->events->attach('foo.bar', function () { return 'zero'; }, 1);
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, [], function ($result) {
             return ($result === 'found');
         });
@@ -217,10 +220,13 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testTriggerUntilShouldMarkResponseCollectionStoppedWhenConditionMetByLastListener()
     {
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function () { return 'bogus'; });
         $this->events->attach('foo.bar', function () { return 'nada'; });
         $this->events->attach('foo.bar', function () { return 'zero'; });
         $this->events->attach('foo.bar', function () { return 'found'; });
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, [], function ($result) {
             return ($result === 'found');
         });
@@ -231,10 +237,13 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testResponseCollectionIsNotStoppedWhenNoCallbackMatchedByTriggerUntil()
     {
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function () { return 'bogus'; }, 4);
         $this->events->attach('foo.bar', function () { return 'nada'; }, 3);
         $this->events->attach('foo.bar', function () { return 'found'; }, 2);
         $this->events->attach('foo.bar', function () { return 'zero'; }, 1);
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, [], function ($result) {
             return ($result === 'never found');
         });
@@ -370,10 +379,13 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testCallingEventsStopPropagationMethodHaltsEventEmission()
     {
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function ($e) { return 'bogus'; }, 4);
         $this->events->attach('foo.bar', function ($e) { $e->stopPropagation(true); return 'nada'; }, 3);
         $this->events->attach('foo.bar', function ($e) { return 'found'; }, 2);
         $this->events->attach('foo.bar', function ($e) { return 'zero'; }, 1);
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, []);
         $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertTrue($responses->stopped());
@@ -385,6 +397,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testCanAlterParametersWithinAEvent()
     {
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function ($e) { $e->setParam('foo', 'bar'); });
         $this->events->attach('foo.bar', function ($e) { $e->setParam('bar', 'baz'); });
         $this->events->attach('foo.bar', function ($e) {
@@ -392,6 +405,8 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             $bar = $e->getParam('bar', '__NO_BAR__');
             return $foo . ":" . $bar;
         });
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, []);
         $this->assertEquals('bar:baz', $responses->last());
     }
@@ -400,8 +415,12 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
     {
         $params = [ 'foo' => 'bar', 'bar' => 'baz'];
         $args   = $this->events->prepareArgs($params);
+
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function ($e) { $e->setParam('foo', 'FOO'); });
         $this->events->attach('foo.bar', function ($e) { $e->setParam('bar', 'BAR'); });
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, $args);
         $this->assertEquals('FOO', $args['foo']);
         $this->assertEquals('BAR', $args['bar']);
@@ -410,8 +429,11 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
     public function testCanPassObjectForEventParameters()
     {
         $params = (object) [ 'foo' => 'bar', 'bar' => 'baz'];
+        // @codingStandardsIgnoreStart
         $this->events->attach('foo.bar', function ($e) { $e->setParam('foo', 'FOO'); });
         $this->events->attach('foo.bar', function ($e) { $e->setParam('bar', 'BAR'); });
+        // @codingStandardsIgnoreEnd
+
         $responses = $this->events->trigger('foo.bar', $this, $params);
         $this->assertEquals('FOO', $params->foo);
         $this->assertEquals('BAR', $params->bar);
@@ -678,7 +700,8 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             $deprecated = true;
         }, E_USER_DEPRECATED);
 
-        $this->events->triggerUntil('foo.bar', $this, ['foo' => 'bar'], function () {});
+        $this->events->triggerUntil('foo.bar', $this, ['foo' => 'bar'], function () {
+        });
         restore_error_handler();
 
         $this->assertTrue($deprecated, 'EventManager::triggerUntil not marked as E_USER_DEPRECATED');
@@ -698,8 +721,10 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testTriggerThrowsInvalidCallbackExceptionForInvalidCallback()
     {
-        $this->setExpectedException('Zend\EventManager\Exception\InvalidCallbackException',
-        'Invalid callback provided');
+        $this->setExpectedException(
+            'Zend\EventManager\Exception\InvalidCallbackException',
+            'Invalid callback provided'
+        );
 
         $responses = $this->events->trigger(
             'foo.bar',
@@ -773,5 +798,53 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
     {
         $responses = $this->events->trigger('string.transform', $this, ['string' => ' foo ']);
         $this->assertNull($responses->last());
+    }
+
+    public function testTriggerEventAcceptsEventInstanceAndTriggersListeners()
+    {
+        $event = $this->prophesize(EventInterface::class);
+        $event->getName()->willReturn('test');
+        $event->propagationIsStopped()->willReturn(false);
+
+        $triggered = false;
+        $this->events->attach('test', function ($e) use ($event, &$triggered) {
+            $this->assertSame($event->reveal(), $e);
+            $triggered = true;
+        });
+
+        $this->events->triggerEvent($event->reveal());
+        $this->assertTrue($triggered, 'Listener for event was not triggered');
+    }
+
+    public function testTriggerEventUntilAcceptsEventInstanceAndTriggersListenersUntilCallbackEvaluatesTrue()
+    {
+        $event = $this->prophesize(EventInterface::class);
+        $event->getName()->willReturn('test');
+        $event->propagationIsStopped()->willReturn(false);
+
+        $callback = function ($result) {
+            return ($result === true);
+        };
+
+        $triggeredOne = false;
+        $this->events->attach('test', function ($e) use ($event, &$triggeredOne) {
+            $this->assertSame($event->reveal(), $e);
+            $triggeredOne = true;
+        });
+
+        $triggeredTwo = false;
+        $this->events->attach('test', function ($e) use ($event, &$triggeredTwo) {
+            $this->assertSame($event->reveal(), $e);
+            $triggeredTwo = true;
+            return true;
+        });
+
+        $this->events->attach('test', function ($e) {
+            $this->fail('Third listener was triggered and should not have been');
+        });
+
+        $this->events->triggerEventUntil($callback, $event->reveal());
+        $this->assertTrue($triggeredOne, 'First Listener for event was not triggered');
+        $this->assertTrue($triggeredTwo, 'First Listener for event was not triggered');
     }
 }


### PR DESCRIPTION
Per #4, we need to mark a number of features as deprecated for an upcoming 2.6.0 release. This should be done against master.

Deprecations can be done via annotations; all deprecations **MUST** also be noted in the CHANGELOG.md.
- [x] Mark GlobalEventManager as deprecated
- [x] Mark StaticEventManager as deprecated
- [x] Mark EventManager(Interface)?::setSharedManager as deprecated
- [x] Mark EventManager(Interface)?::getEvents as deprecated
- [x] Mark EventManager(Interface)?::getListeners as deprecated
- [x] Mark EventManager(Interface)?::setEventClass as deprecated
- [x] Mark EventManager(Interface)?::attachAggregate as deprecated
- [x] Mark EventManager(Interface)?::detachAggregate as deprecated
- [x] Mark SharedListenerAggregateInterface as deprecated
- [x] Mark SharedEventAggregateAwareInterface as deprecated
- [x] Mark SharedEventManagerAwareInterface as deprecated
- [x] Mark SharedEventManagerInterface::getEvents as deprecated
- [x] Add EventManager::triggerEvent() (but not at interface level)
- [x] Add EventManager::triggerEventUntil() (but not at interface level)
