### PR TITLE
Performance increasement by integer priority

### DIFF
--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -164,7 +164,7 @@ class EventManager implements EventManagerInterface
             ));
         }
 
-        $this->events[$eventName][((int) $priority) . '.0'][] = $listener;
+        $this->events[$eventName][(int) $priority][] = $listener;
 
         return $listener;
     }
@@ -296,13 +296,19 @@ class EventManager implements EventManagerInterface
      */
     private function getListenersByEventName($eventName)
     {
-        $listeners = array_merge_recursive(
-            isset($this->events[$eventName]) ? $this->events[$eventName] : [],
-            isset($this->events['*']) ? $this->events['*'] : [],
-            $this->sharedManager ? $this->sharedManager->getListeners($this->identifiers, $eventName) : []
-        );
+        $listeners = isset($this->events[$eventName]) ? $this->events[$eventName] : [];
+        if (isset($this->events['*'])) {
+            foreach ($this->events['*'] as $p => $l) {
+                $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+            }
+        }
+        if ($this->sharedManager) {
+            foreach ($this->sharedManager->getListeners($this->identifiers, $eventName) as $p => $l) {
+                $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+            }
+        }
 
-        krsort($listeners, SORT_NUMERIC);
+        krsort($listeners);
 
         $listenersForEvent = [];
 

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -132,8 +132,14 @@ class EventManager implements EventManagerInterface
     {
         $event = clone $this->eventPrototype;
         $event->setName($eventName);
-        $event->setTarget($target);
-        $event->setParams($argv);
+
+        if ($target !== null) {
+            $event->setTarget($target);
+        }
+
+        if ($argv) {
+            $event->setParams($argv);
+        }
 
         return $this->triggerListeners($event);
     }
@@ -145,8 +151,14 @@ class EventManager implements EventManagerInterface
     {
         $event = clone $this->eventPrototype;
         $event->setName($eventName);
-        $event->setTarget($target);
-        $event->setParams($argv);
+
+        if ($target !== null) {
+            $event->setTarget($target);
+        }
+
+        if ($argv) {
+            $event->setParams($argv);
+        }
 
         return $this->triggerListeners($event, $callback);
     }
@@ -226,22 +238,21 @@ class EventManager implements EventManagerInterface
                     break;
                 }
             }
+        }
 
-            // If the queue for the given event is empty, remove it.
-            if (empty($this->events[$eventName])) {
-                unset($this->events[$eventName]);
-                break;
-            }
+        // If the queue for the given event is empty, remove it.
+        if (empty($this->events[$eventName])) {
+            unset($this->events[$eventName]);
         }
     }
 
     /**
      * @inheritDoc
      */
-    public function clearListeners($event)
+    public function clearListeners($eventName)
     {
-        if (isset($this->events[$event])) {
-            unset($this->events[$event]);
+        if (isset($this->events[$eventName])) {
+            unset($this->events[$eventName]);
         }
     }
 

--- a/src/SharedEventManager.php
+++ b/src/SharedEventManager.php
@@ -74,7 +74,7 @@ class SharedEventManager implements SharedEventManagerInterface
             ));
         }
 
-        $this->identifiers[$identifier][$event][((int) $priority) . '.0'][] = $listener;
+        $this->identifiers[$identifier][$event][(int) $priority][] = $listener;
     }
 
     /**
@@ -178,22 +178,30 @@ class SharedEventManager implements SharedEventManagerInterface
             }
 
             $listenersByIdentifier = isset($this->identifiers[$identifier]) ? $this->identifiers[$identifier] : [];
-
-            $listeners = array_merge_recursive(
-                $listeners,
-                isset($listenersByIdentifier[$eventName]) ? $listenersByIdentifier[$eventName] : [],
-                isset($listenersByIdentifier['*']) ? $listenersByIdentifier['*'] : []
-            );
+            if (isset($listenersByIdentifier[$eventName])) {
+                foreach ($listenersByIdentifier[$eventName] as $p => $l) {
+                    $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+                }
+            }
+            if (isset($listenersByIdentifier['*'])) {
+                foreach ($listenersByIdentifier['*'] as $p => $l) {
+                    $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+                }
+            }
         }
 
-        if (isset($this->identifiers['*']) && ! in_array('*', $identifiers)) {
+        if (isset($this->identifiers['*']) && ! in_array('*', $identifiers, true)) {
             $wildcardIdentifier = $this->identifiers['*'];
-
-            $listeners = array_merge_recursive(
-                $listeners,
-                isset($wildcardIdentifier[$eventName]) ? $wildcardIdentifier[$eventName] : [],
-                isset($wildcardIdentifier['*']) ? $wildcardIdentifier['*'] : []
-            );
+            if (isset($wildcardIdentifier[$eventName])) {
+                foreach ($wildcardIdentifier[$eventName] as $p => $l) {
+                    $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+                }
+            }
+            if (isset($wildcardIdentifier['*'])) {
+                foreach ($wildcardIdentifier['*'] as $p => $l) {
+                    $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+                }
+            }
         }
 
         return $listeners;

--- a/src/SharedEventManager.php
+++ b/src/SharedEventManager.php
@@ -141,7 +141,6 @@ class SharedEventManager implements SharedEventManagerInterface
                 unset($this->identifiers[$identifier][$eventName]);
                 break;
             }
-
         }
 
         // Is the identifier queue now empty? Remove it.

--- a/src/SharedEventManager.php
+++ b/src/SharedEventManager.php
@@ -190,7 +190,7 @@ class SharedEventManager implements SharedEventManagerInterface
             }
         }
 
-        if (isset($this->identifiers['*']) && ! in_array('*', $identifiers, true)) {
+        if (isset($this->identifiers['*'])) {
             $wildcardIdentifier = $this->identifiers['*'];
             if (isset($wildcardIdentifier[$eventName])) {
                 foreach ($wildcardIdentifier[$eventName] as $p => $l) {

--- a/src/Test/EventListenerIntrospectionTrait.php
+++ b/src/Test/EventListenerIntrospectionTrait.php
@@ -66,13 +66,16 @@ trait EventListenerIntrospectionTrait
     {
         $r = new ReflectionProperty($events, 'events');
         $r->setAccessible(true);
-        $listeners = $r->getValue($events);
+        $internal = $r->getValue($events);
 
-        if (! isset($listeners[$event])) {
-            return $this->traverseListeners([]);
+        $listeners = [];
+        foreach (isset($internal[$event]) ? $internal[$event] : [] as $p => $listOfListeners) {
+            foreach ($listOfListeners as $l) {
+                $listeners[$p] = isset($listeners[$p]) ? array_merge($listeners[$p], $l) : $l;
+            }
         }
 
-        return $this->traverseListeners($listeners[$event], $withPriority);
+        return $this->traverseListeners($listeners, $withPriority);
     }
 
     /**

--- a/test/EventManagerTest.php
+++ b/test/EventManagerTest.php
@@ -56,7 +56,12 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $r->setAccessible(true);
         $events = $r->getValue($manager);
 
-        return isset($events[$event]) ? $events[$event] : [];
+        $listenersByPriority = isset($events[$event]) ? $events[$event] : [];
+        foreach ($listenersByPriority as $priority => & $listeners) {
+            $listeners = $listeners[0];
+        }
+
+        return $listenersByPriority;
     }
 
     public function testAttachShouldAddListenerToEvent()

--- a/test/SharedEventManagerTest.php
+++ b/test/SharedEventManagerTest.php
@@ -27,7 +27,7 @@ class SharedEventManagerTest extends TestCase
 
     public function getListeners(SharedEventManager $manager, array $identifiers, $event, $priority = 1)
     {
-        $priority = (int) $priority . '.0';
+        $priority = (int) $priority;
         $listeners = $manager->getListeners($identifiers, $event);
         if (! isset($listeners[$priority])) {
             return [];
@@ -247,7 +247,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->clearListeners('IDENTIFIER', 'EVENT');
 
         // getListeners() always pulls in wildcard listeners
-        $this->assertEquals(['1.0' => [
+        $this->assertEquals([1 => [
             $this->callback,
         ]], $this->manager->getListeners([ 'IDENTIFIER' ], 'EVENT'));
     }

--- a/test/TestAsset/StaticEventsMock.php
+++ b/test/TestAsset/StaticEventsMock.php
@@ -30,7 +30,6 @@ class StaticEventsMock implements SharedEventManagerInterface
      */
     public function attach($identifier, $event, callable $listener, $priority = 1)
     {
-
     }
 
     /**


### PR DESCRIPTION
After my PR #16 I experimented with integer priorities.

It's no longer storing priorities as string with `.0` suffix but store as integer. This makes it harder to merge listeners of the same priority by name, wildcard or shared but in the end I sow a very good performance improvement, only `MultipleEventMultipleSharedListener` decreases a little (see below).

All tests passed for me but it should be tested carefully anyway ;)
# PHP 5.6

PHP 5.6.14-0+deb8u1 (cli) (built: Oct  4 2015 16:13:10) 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies
## Branch: develop

```
ZendBench\EventManager\MultipleEventIndividualSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000237437248] [42,116.39107]


ZendBench\EventManager\MultipleEventLocalListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000196894646] [50,788.58272]


ZendBench\EventManager\MultipleEventMultipleLocalAndSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0002710880280] [3,688.83867]


ZendBench\EventManager\MultipleEventMultipleSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000575615883] [17,372.69644]


ZendBench\EventManager\SingleEventMultipleListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000446063042] [22,418.35585]


ZendBench\EventManager\SingleEventMultipleSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000478469849] [20,899.95854]


ZendBench\EventManager\SingleEventSingleListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000078002930] [128,200.31299]


ZendBench\EventManager\SingleEventSingleSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000106687546] [93,731.65281]
```
## Branch: integer_priority

```
ZendBench\EventManager\MultipleEventIndividualSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000230637074] [43,358.16375]


ZendBench\EventManager\MultipleEventLocalListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000166062355] [60,218.34387]


ZendBench\EventManager\MultipleEventMultipleLocalAndSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0002452962399] [4,076.70334]


ZendBench\EventManager\MultipleEventMultipleSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000640497684] [15,612.85894]


ZendBench\EventManager\SingleEventMultipleListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000399168015] [25,052.10747]


ZendBench\EventManager\SingleEventMultipleSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000434321880] [23,024.39838]


ZendBench\EventManager\SingleEventSingleListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000066055775] [151,387.21856]


ZendBench\EventManager\SingleEventSingleSharedListener
    Method Name   Iterations    Average Time      Ops/second
    -------  ------------  --------------    -------------
    trigger: [5,000     ] [0.0000096778870] [103,328.34056]
```
# PHP 7.0

PHP 7.0.0 (cli) (built: Dec  5 2015 23:50:11) ( NTS )
Copyright (c) 1997-2015 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies

```
Fatal error: Uncaught TypeError: Argument 1 passed to Athletic\Common\CmdLineErrorHandler::handleException() must be an instance of Exception, instance of Error given in /home/mabe/workspace/zend-eventmanager/vendor/athletic/athletic/src/Athletic/Common/CmdLineErrorHandler.php:35
Stack trace:
#0 [internal function]: Athletic\Common\CmdLineErrorHandler->handleException(Object(Error))
#1 {main}
  thrown in /home/mabe/workspace/zend-eventmanager/vendor/athletic/athletic/src/Athletic/Common/CmdLineErrorHandler.php on line 35
```

Something with athletic doesn't work with PHP-7 but I have no time to figure that out.
