### PR TITLE
Updated dependencies for 2.6 series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "^2.7 || ^3.0"
+        "zendframework/zend-stdlib": "^2.7"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,16 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6-dev",
-            "dev-develop": "3.0-dev"
+            "dev-release-2.6": "2.6-dev",
+            "dev-master": "3.0-dev",
+            "dev-develop": "3.1-dev"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
- PHP => `^5.5 || ^7.0`
- zend-stdlib => `^2.7 || ^3.0`

Also updated branch aliases:
- dev-release-2.6 => 2.6-dev
- dev-master => 3.0-dev
- dev-develop => 3.1-dev
