### PR TITLE
[docs] Fix order of params in quick start

### DIFF
--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -142,7 +142,7 @@ $sharedEvents->attach('Foo', 'bar', function ($e) use ($log) {
 
 // Later, instantiate Foo:
 $foo = new Foo();
-$foo->setEventManager(new EventManager([], $sharedEvents));
+$foo->setEventManager(new EventManager($sharedEvents, []));
 
 // And we can still trigger the above event:
 $foo->bar('baz', 'bat');


### PR DESCRIPTION
EventManager's constructor takes the sharedEventManager first, then the list of identifiers.
