### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "q6mC+KhLKsPYD22R9RI7lLhQGF5dSQ0QttmaFSQf/wtIntruVIFoyWt8ObR3zFsZ4xxra8MZFV2AjbMM9vqB28aHZ1jV5kbCbhTfSbdv0GT4nwqIHh84Ui7gCykJBqyyboWf/ekOv87cbuTg3EbqJcgdBh6/oyRGIVVB3HQayJJTTUCz+TQ/M4mpvOE+61FGpu6WLv465R8aKRi0ZLjk6qMtAY616cnGlPBOoNopyQM2+VTGyLOFgwnCUae3l4MSc8zsWgA4FLwttsYOzoVXit1ZXcqAt+XCAxUMntT3esIKVdeNejqQ7ZhMdMJpbdXTgfOD9kPt4fbNrcyg12Zkl0F3lHUNMb22PWNXb7tZ3+E4pR8B+6GtKXLRleEl9sPUKhxZ0CgwQErqOE8Osnw+BeNjueosNzJvrpxdHLX1a1+1v4VZIcikK+btW6YS+YLjZJgd80LI/4vQByUehgfFRuJnmjkMp+p9NN+PphdYHcQLfe2VU+qif114cR2WAyaiJ47zXMu2+vqp9sR20M2CfKZXrihiSO+CdbhSmep3sWaCuLWZtpsMx7u3rKl1o5doGLmkYAc+OaCEw5mZ/nVxzkH2ldNNcCeV2+ENKj4zlKoVXy1MB0KTT2U2rJ4pO5WhYLORbgBNNKeuD8r5nl65Dhn3gaIPXvlica/jIqay+/U="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
