### PR TITLE
spelling fixes

### DIFF
--- a/doc/book/api.md
+++ b/doc/book/api.md
@@ -244,7 +244,7 @@ Attach a listener to a named event triggered by an identified context, where:
 ### detach()
 
 ```php
-detach(callable $listener, $identifer = null, $eventName = null) : void
+detach(callable $listener, $identifier = null, $eventName = null) : void
 ```
 
 Detach a listener, optionally from a single identifier, and optionally from a

--- a/doc/book/migration/changed.md
+++ b/doc/book/migration/changed.md
@@ -60,7 +60,7 @@ trigger($event, $target = null, $argv = []);
 triggerUntil(callable $callback, $event, $target = null, $argv = []);
 ```
 
-with the following defintions:
+with the following definitions:
 
 - `$event` is a string event name.
 - `$target` is a value representing the target of the event.

--- a/doc/book/tutorial.md
+++ b/doc/book/tutorial.md
@@ -314,7 +314,7 @@ class LogEvents implements ListenerAggregateInterface
 >
 > The trait `Zend\EventManager\ListenerAggregateTrait` can be composed to help
 > implement `ListenerAggregateInterface`; it defines the `$listeners` property,
-> and the `detach()` logic as demostrated above.
+> and the `detach()` logic as demonstrated above.
 
 You can attach this by passing the event manager to the aggregate's `attach()`
 method:
@@ -548,7 +548,7 @@ stored in the object, and also to ensure the listeners have the exact same
 context as the calling method. But it raises an interesting problem in this
 example: what name do we give the result of the method? One standard that has
 emerged is the use of `__RESULT__`, as double-underscored variables are
-typically reserved for the sytem.
+typically reserved for the system.
 
 Here's what the method will look like:
 

--- a/test/EventManagerAwareTraitTest.php
+++ b/test/EventManagerAwareTraitTest.php
@@ -51,7 +51,7 @@ class EventManagerAwareTraitTest extends TestCase
 
         $object->setEventManager($eventManager);
 
-        //check that the identifer has been added.
+        //check that the identifier has been added.
         $this->assertContains($eventIdentifier, $eventManager->getIdentifiers());
 
         //check that the method attachDefaultListeners has been called


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.