### PR TITLE
Clarify comment

### DIFF
--- a/src/SharedEventManager.php
+++ b/src/SharedEventManager.php
@@ -27,9 +27,8 @@ class SharedEventManager implements SharedEventManagerInterface
     /**
      * Attach a listener to an event emitted by components with specific identifiers.
      *
-     * Allows attaching a listener to an event offered by an identifying
-     * components. As an example, the following connects to the "getAll" event
-     * of both an AbstractResource and EntityResource:
+     * As an example, the following connects to the "getAll" event of both an
+     * AbstractResource and EntityResource:
      *
      * <code>
      * $sharedEventManager = new SharedEventManager();


### PR DESCRIPTION
The removed sentence:

a) Repeats the one above it
b) Introduces new terminology: "offered"
c) Has a grammatical error "by an identifying components"

After tripping up on it, I realized the sentence right above was perfect and could replace it.

Minor, but I hope it helps someone!